### PR TITLE
resolution strategy removed for Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,12 +104,6 @@ kapt {
     correctErrorTypes = true
 }
 
-configurations.all {
-    resolutionStrategy {
-        force "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
-    }
-}
-
 dependencies {
 
     // App dependencies


### PR DESCRIPTION
This resolution strategy may cause runtime compatibility problems when the Kotlin plugin version gets an update or in case of any version incompatibility